### PR TITLE
Store change request rejection reason

### DIFF
--- a/crates/orbflow-core/src/versioning.rs
+++ b/crates/orbflow-core/src/versioning.rs
@@ -170,6 +170,9 @@ pub struct ChangeRequest {
     pub base_version: i32,
     /// Current status.
     pub status: ChangeRequestStatus,
+    /// Why the CR was rejected, if applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rejection_reason: Option<String>,
     /// Who created the CR.
     pub author: String,
     /// Assigned reviewers.
@@ -296,6 +299,7 @@ mod tests {
             proposed_definition: v2_definition(),
             base_version: 1,
             status: ChangeRequestStatus::Open,
+            rejection_reason: None,
             author: "alice".into(),
             reviewers: vec!["bob".into()],
             comments: vec![ReviewComment {

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2910,6 +2910,7 @@ pub async fn create_change_request(
         proposed_definition: body.proposed_definition,
         base_version: body.base_version,
         status: orbflow_core::ChangeRequestStatus::Draft,
+        rejection_reason: None,
         author: body.author,
         reviewers: body.reviewers,
         comments: Vec::new(),

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -3257,7 +3257,6 @@ pub async fn reject_change_request(
     State(state): State<AppState>,
     axum::Extension(auth_user): axum::Extension<AuthUser>,
     Path(params): Path<ChangeRequestPathParams>,
-    // TODO: store body.reason when ChangeRequest gains a rejection_reason field
     Json(body): Json<RejectChangeRequestBody>,
 ) -> Response {
     if let Err(resp) = check_permission(
@@ -3270,8 +3269,6 @@ pub async fn reject_change_request(
     ) {
         return resp;
     }
-
-    let _ = &body; // acknowledge the body to suppress unused warnings
 
     let store = match &state.change_request_store {
         Some(s) => s,
@@ -3310,6 +3307,7 @@ pub async fn reject_change_request(
 
     let updated = orbflow_core::ChangeRequest {
         status: orbflow_core::ChangeRequestStatus::Rejected,
+        rejection_reason: body.reason,
         updated_at: Utc::now(),
         ..cr
     };

--- a/crates/orbflow-memstore/src/store.rs
+++ b/crates/orbflow-memstore/src/store.rs
@@ -150,7 +150,7 @@ impl WorkflowStore for MemStore {
             .iter()
             .map(deep_clone)
             .collect::<Result<Vec<_>, _>>()?;
-        all.sort_by(|a, b| b.version.cmp(&a.version));
+        all.sort_by_key(|b| std::cmp::Reverse(b.version));
         let total = all.len() as i64;
         let page = paginate(&all, &opts);
         Ok((page, total))
@@ -416,7 +416,7 @@ impl ChangeRequestStore for MemStore {
             .map(deep_clone)
             .collect::<Result<Vec<_>, _>>()?;
         // Sort by created_at descending (newest first), matching Postgres behavior.
-        filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        filtered.sort_by_key(|b| std::cmp::Reverse(b.created_at));
         let total = filtered.len() as i64;
         let page = paginate(&filtered, &opts);
         Ok((page, total))

--- a/crates/orbflow-memstore/src/store.rs
+++ b/crates/orbflow-memstore/src/store.rs
@@ -1063,6 +1063,7 @@ mod tests {
             proposed_definition: serde_json::json!({"nodes": [], "edges": []}),
             base_version: 1,
             status: ChangeRequestStatus::Open,
+            rejection_reason: None,
             author: "alice".into(),
             reviewers: vec!["bob".into()],
             comments: vec![],

--- a/crates/orbflow-memstore/tests/change_request_lifecycle.rs
+++ b/crates/orbflow-memstore/tests/change_request_lifecycle.rs
@@ -80,6 +80,7 @@ fn make_change_request(
         }),
         base_version,
         status,
+        rejection_reason: None,
         author: "alice".into(),
         reviewers: vec!["bob".into()],
         comments: vec![],

--- a/crates/orbflow-postgres/src/change_request.rs
+++ b/crates/orbflow-postgres/src/change_request.rs
@@ -28,6 +28,7 @@ struct ChangeRequestRow {
     status: String,
     author: String,
     reviewers: serde_json::Value,
+    rejection_reason: Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -45,6 +46,7 @@ struct ChangeRequestRowWithTotal {
     status: String,
     author: String,
     reviewers: serde_json::Value,
+    rejection_reason: Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
     total: i64,
@@ -76,6 +78,7 @@ struct ChangeRequestFields<'a> {
     status: &'a str,
     author: &'a str,
     reviewers: &'a serde_json::Value,
+    rejection_reason: &'a Option<String>,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 }
@@ -102,6 +105,7 @@ fn map_change_request_fields(f: ChangeRequestFields<'_>) -> Result<ChangeRequest
         status,
         author: f.author.to_string(),
         reviewers,
+        rejection_reason: f.rejection_reason.clone(),
         comments: Vec::new(),
         created_at: f.created_at,
         updated_at: f.updated_at,
@@ -119,6 +123,7 @@ fn row_to_change_request(row: &ChangeRequestRow) -> Result<ChangeRequest, Orbflo
         status: &row.status,
         author: &row.author,
         reviewers: &row.reviewers,
+        rejection_reason: &row.rejection_reason,
         created_at: row.created_at,
         updated_at: row.updated_at,
     })
@@ -137,6 +142,7 @@ fn row_to_change_request_from_total(
         status: &row.status,
         author: &row.author,
         reviewers: &row.reviewers,
+        rejection_reason: &row.rejection_reason,
         created_at: row.created_at,
         updated_at: row.updated_at,
     })
@@ -174,8 +180,8 @@ impl PgStore {
         })?;
 
         sqlx::query(
-            r#"INSERT INTO change_requests (id, workflow_id, title, description, proposed_definition, base_version, status, author, reviewers, created_at, updated_at)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"#,
+            r#"INSERT INTO change_requests (id, workflow_id, title, description, proposed_definition, base_version, status, author, reviewers, rejection_reason, created_at, updated_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)"#,
         )
         .bind(&cr.id)
         .bind(cr.workflow_id.0.as_str())
@@ -186,6 +192,7 @@ impl PgStore {
         .bind(status_str)
         .bind(&cr.author)
         .bind(&reviewers_val)
+        .bind(&cr.rejection_reason)
         .bind(cr.created_at)
         .bind(cr.updated_at)
         .execute(&self.pool)
@@ -200,7 +207,7 @@ impl PgStore {
     /// Gets a change request by ID, including its comments.
     pub(crate) async fn get_change_request(&self, id: &str) -> Result<ChangeRequest, OrbflowError> {
         let row: ChangeRequestRow = sqlx::query_as(
-            r#"SELECT id, workflow_id, title, description, proposed_definition, base_version, status, author, reviewers, created_at, updated_at
+            r#"SELECT id, workflow_id, title, description, proposed_definition, base_version, status, author, reviewers, rejection_reason, created_at, updated_at
                FROM change_requests
                WHERE id = $1"#,
         )
@@ -255,7 +262,7 @@ impl PgStore {
 
             sqlx::query_as(
                 r#"SELECT id, workflow_id, title, description, proposed_definition,
-                          base_version, status, author, reviewers, created_at, updated_at,
+                          base_version, status, author, reviewers, rejection_reason, created_at, updated_at,
                           COUNT(*) OVER() AS total
                    FROM change_requests
                    WHERE workflow_id = $1 AND status = $2
@@ -276,7 +283,7 @@ impl PgStore {
         } else {
             sqlx::query_as(
                 r#"SELECT id, workflow_id, title, description, proposed_definition,
-                          base_version, status, author, reviewers, created_at, updated_at,
+                          base_version, status, author, reviewers, rejection_reason, created_at, updated_at,
                           COUNT(*) OVER() AS total
                    FROM change_requests
                    WHERE workflow_id = $1
@@ -319,14 +326,15 @@ impl PgStore {
 
         let result = sqlx::query(
             r#"UPDATE change_requests
-               SET title = $1, description = $2, proposed_definition = $3, status = $4, reviewers = $5, updated_at = $6
-               WHERE id = $7"#,
+               SET title = $1, description = $2, proposed_definition = $3, status = $4, reviewers = $5, rejection_reason = $6, updated_at = $7
+               WHERE id = $8"#,
         )
         .bind(&cr.title)
         .bind(&cr.description)
         .bind(&cr.proposed_definition)
         .bind(status_str)
         .bind(&reviewers_val)
+        .bind(&cr.rejection_reason)
         .bind(cr.updated_at)
         .bind(&cr.id)
         .execute(&self.pool)

--- a/crates/orbflow-postgres/src/migrate.rs
+++ b/crates/orbflow-postgres/src/migrate.rs
@@ -280,6 +280,13 @@ ALTER TABLE credentials
     ADD COLUMN IF NOT EXISTS policy JSONB;
 "#,
     ),
+    (
+        "016_cr_rejection_reason",
+        r#"
+ALTER TABLE change_requests
+    ADD COLUMN IF NOT EXISTS rejection_reason TEXT;
+"#,
+    ),
 ];
 
 /// Runs all embedded migrations in order.


### PR DESCRIPTION
This change implements the storage of a rejection reason when a workflow change request is rejected. 

Key changes:
- Domain model: Added `rejection_reason: Option<String>` to `ChangeRequest` in `orbflow-core`.
- Database: Added a migration to `orbflow-postgres` to add the corresponding column.
- Persistence: Updated both PostgreSQL and in-memory stores to handle the new field.
- API: Updated the Axum handler in `orbflow-httpapi` to extract the `reason` from the JSON request body and save it with the rejected status.

Verified by code review and manual inspection of the implementation across all layers.

---
*PR created automatically by Jules for task [10706225131449366462](https://jules.google.com/task/10706225131449366462) started by @Etherll*