### PR TITLE
⚡ [performance] optimize event loading with functional refactor

### DIFF
--- a/crates/orbflow-memstore/src/store.rs
+++ b/crates/orbflow-memstore/src/store.rs
@@ -150,7 +150,7 @@ impl WorkflowStore for MemStore {
             .iter()
             .map(deep_clone)
             .collect::<Result<Vec<_>, _>>()?;
-        all.sort_by(|a, b| b.version.cmp(&a.version));
+        all.sort_by_key(|v| std::cmp::Reverse(v.version));
         let total = all.len() as i64;
         let page = paginate(&all, &opts);
         Ok((page, total))
@@ -416,7 +416,7 @@ impl ChangeRequestStore for MemStore {
             .map(deep_clone)
             .collect::<Result<Vec<_>, _>>()?;
         // Sort by created_at descending (newest first), matching Postgres behavior.
-        filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        filtered.sort_by_key(|cr| std::cmp::Reverse(cr.created_at));
         let total = filtered.len() as i64;
         let page = paginate(&filtered, &opts);
         Ok((page, total))

--- a/crates/orbflow-postgres/src/event.rs
+++ b/crates/orbflow-postgres/src/event.rs
@@ -147,18 +147,16 @@ impl EventStore for PgStore {
             ))
         })?;
 
-        let mut events = Vec::with_capacity(rows.len());
-        for row in &rows {
-            let event: DomainEvent = serde_json::from_value(row.data.clone()).map_err(|e| {
-                OrbflowError::Database(format!(
-                    "postgres: deserialize event type {} for instance {}: {e}",
-                    row.event_type, row.instance_id
-                ))
-            })?;
-            events.push(event);
-        }
-
-        Ok(events)
+        rows.into_iter()
+            .map(|row| {
+                serde_json::from_value(row.data).map_err(|e| {
+                    OrbflowError::Database(format!(
+                        "postgres: deserialize event type {} for instance {}: {e}",
+                        row.event_type, row.instance_id
+                    ))
+                })
+            })
+            .collect()
     }
 
     async fn save_snapshot(&self, inst: &Instance) -> Result<(), OrbflowError> {
@@ -234,21 +232,21 @@ impl EventStore for PgStore {
             ))
         })?;
 
-        let mut records = Vec::with_capacity(rows.len());
-        for (seq, row) in rows.into_iter().enumerate() {
-            let event_data = serde_json::to_vec(&row.data).map_err(|e| {
-                OrbflowError::Database(format!("postgres: serialize audit event data: {e}"))
-            })?;
-            records.push(audit::AuditRecord {
-                prev_hash: row
-                    .prev_hash
-                    .unwrap_or_else(|| audit::GENESIS_HASH.to_string()),
-                event_hash: row.event_hash.unwrap_or_default(),
-                event_data,
-                seq: seq as u64,
-            });
-        }
-
-        Ok(records)
+        rows.into_iter()
+            .enumerate()
+            .map(|(seq, row)| {
+                let event_data = serde_json::to_vec(&row.data).map_err(|e| {
+                    OrbflowError::Database(format!("postgres: serialize audit event data: {e}"))
+                })?;
+                Ok(audit::AuditRecord {
+                    prev_hash: row
+                        .prev_hash
+                        .unwrap_or_else(|| audit::GENESIS_HASH.to_string()),
+                    event_hash: row.event_hash.unwrap_or_default(),
+                    event_data,
+                    seq: seq as u64,
+                })
+            })
+            .collect()
     }
 }


### PR DESCRIPTION
💡 **What:** Refactored manual loops into functional pipelines using `.into_iter().map().collect()` in `crates/orbflow-postgres/src/event.rs`.

🎯 **Why:** To improve code readability and performance. By using `into_iter()`, we consume the database rows directly, allowing us to move the `serde_json::Value` (data) into the deserializer instead of cloning it.

📊 **Measured Improvement:** Direct performance measurement was impractical due to environment limitations (no network for cargo dependencies). However, the change is a guaranteed net performance improvement as it eliminates $O(N)$ clones of JSON values where $N$ is the number of events. Capacity is still pre-allocated by `.collect()` thanks to `size_hint` from the source `Vec`.

---
*PR created automatically by Jules for task [9168332812506666843](https://jules.google.com/task/9168332812506666843) started by @Etherll*