### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS bypass via control characters in isSafeUrl

### DIFF
--- a/apps/web/src/lib/output-safety.test.ts
+++ b/apps/web/src/lib/output-safety.test.ts
@@ -178,12 +178,19 @@ describe("isSafeUrl", () => {
     expect(isSafeUrl("JAVASCRIPT:alert(1)")).toBe(false);
   });
 
+  it("blocks vbscript: URLs", () => {
+    expect(isSafeUrl("vbscript:msgbox(1)")).toBe(false);
+    expect(isSafeUrl("VBSCRIPT:msgbox(1)")).toBe(false);
+  });
+
   it("blocks data:text/html URLs", () => {
     expect(isSafeUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isSafeUrl("data: text/html,<script>alert(1)</script>")).toBe(false);
   });
 
   it("blocks data:application URLs", () => {
     expect(isSafeUrl("data:application/javascript,alert(1)")).toBe(false);
+    expect(isSafeUrl("data: application/javascript,alert(1)")).toBe(false);
   });
 
   it("allows relative paths", () => {
@@ -192,6 +199,12 @@ describe("isSafeUrl", () => {
 
   it("trims whitespace", () => {
     expect(isSafeUrl("  javascript:alert(1)  ")).toBe(false);
+  });
+
+  it("strips control characters to prevent bypass", () => {
+    expect(isSafeUrl("\x01javascript:alert(1)")).toBe(false);
+    expect(isSafeUrl("java\x09script:alert(1)")).toBe(false); // Tab is a control character sometimes stripped, but \x09 is in \x00-\x1F
+    expect(isSafeUrl("\x00data:text/html;base64,PHNjcmlwdD4=")).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/output-safety.ts
+++ b/apps/web/src/lib/output-safety.ts
@@ -95,12 +95,22 @@ export function extractContentType(headers: unknown): string | null {
   return null;
 }
 
-/** Block unsafe URL schemes that are XSS vectors (javascript:, data:text/html, etc). */
-const UNSAFE_URL_SCHEMES = ["javascript:", "data:text/html", "data:application/"] as const;
+/** Block unsafe URL schemes that are XSS vectors (javascript:, vbscript:, etc). */
+const UNSAFE_URL_SCHEMES = ["javascript:", "vbscript:"] as const;
 
 export function isSafeUrl(url: string): boolean {
-  const lower = url.trim().toLowerCase();
-  return !UNSAFE_URL_SCHEMES.some((scheme) => lower.startsWith(scheme));
+  // Remove all non-printable control characters and trim
+  const cleaned = url.replace(/[\x00-\x1F\x7F-\x9F]/g, "").trim().toLowerCase();
+
+  if (cleaned.startsWith("data:")) {
+    // Parse MIME type from data URI (e.g., data:text/html;base64,...)
+    const mimePart = cleaned.substring(5).split(',')[0].split(';')[0].trim();
+    if (mimePart === "text/html" || mimePart.startsWith("application/")) {
+      return false;
+    }
+  }
+
+  return !UNSAFE_URL_SCHEMES.some((scheme) => cleaned.startsWith(scheme));
 }
 
 interface OutputAnalysis {


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS bypass via control characters in isSafeUrl

🚨 Severity: HIGH
💡 Vulnerability: The `isSafeUrl` function used a basic blacklist for unsafe schemes but could be bypassed by inserting non-printable control characters before or within the scheme string, or by exploiting space characters inside `data:` URIs.
🎯 Impact: Attackers could execute arbitrary JavaScript via XSS if user-controlled input was rendered as a URL in the UI.
🔧 Fix:
- Stripped all non-printable control characters `[\x00-\x1F\x7F-\x9F]` before matching.
- Added `vbscript:` to the `UNSAFE_URL_SCHEMES` blacklist.
- Enhanced `data:` URI handling by parsing out and checking the MIME type accurately.
✅ Verification: Added tests for the various bypass cases in `apps/web/src/lib/output-safety.test.ts`. Tests ran and pass.

---
*PR created automatically by Jules for task [4913741980986713870](https://jules.google.com/task/4913741980986713870) started by @Etherll*