### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS bypass via URL scheme obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The application was using `char::is_alphanumeric()` to validate plugin names and repositories. This Rust method allows all Unicode alphanumeric characters, meaning names with Cyrillic or Greek characters could pass validation.
 **Learning:** `char::is_alphanumeric()` in Rust is not ASCII-restricted and can lead to homograph attacks, where an attacker registers a plugin with a visually identical name using non-ASCII characters.
 **Prevention:** Always use `char::is_ascii_alphanumeric()` when validating system identifiers, URLs, or file paths where you expect standard ASCII characters.
+## 2026-05-16 - [HIGH] Prevent XSS bypass via URL scheme obfuscation with control characters
+**Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
+**Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
+**Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.

--- a/apps/web/src/lib/output-safety.test.ts
+++ b/apps/web/src/lib/output-safety.test.ts
@@ -193,6 +193,13 @@ describe("isSafeUrl", () => {
   it("trims whitespace", () => {
     expect(isSafeUrl("  javascript:alert(1)  ")).toBe(false);
   });
+
+  it("blocks javascript: URLs obfuscated with control characters", () => {
+    expect(isSafeUrl("\x01javascript:alert(1)")).toBe(false);
+    expect(isSafeUrl("java\x09script:alert(1)")).toBe(false);
+    expect(isSafeUrl("java\x00script:alert(1)")).toBe(false);
+    expect(isSafeUrl("\x0Bjavascript:alert(1)")).toBe(false);
+  });
 });
 
 describe("analyzeOutput", () => {

--- a/apps/web/src/lib/output-safety.ts
+++ b/apps/web/src/lib/output-safety.ts
@@ -99,7 +99,10 @@ export function extractContentType(headers: unknown): string | null {
 const UNSAFE_URL_SCHEMES = ["javascript:", "data:text/html", "data:application/"] as const;
 
 export function isSafeUrl(url: string): boolean {
-  const lower = url.trim().toLowerCase();
+  // Strip non-printable control characters before checking to prevent XSS bypasses
+  // This removes characters in the \x00-\x1F and \x7F-\x9F ranges
+  const sanitizedUrl = url.replace(/[\x00-\x1F\x7F-\x9F]/g, "");
+  const lower = sanitizedUrl.trim().toLowerCase();
   return !UNSAFE_URL_SCHEMES.some((scheme) => lower.startsWith(scheme));
 }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `isSafeUrl` function was vulnerable to XSS bypasses because it did not handle non-printable control characters. Browsers are lenient and will ignore characters like `\x01` or tabs (`\x09`) in URL schemes. This allowed attackers to craft malicious URLs (e.g., `java\x09script:alert(1)`) that bypass the safety checks but are still executed by the browser.
🎯 **Impact:** An attacker could execute arbitrary JavaScript in the context of the application by supplying a specially crafted URL, leading to a Cross-Site Scripting (XSS) vulnerability.
🔧 **Fix:** Sanitized the URL string by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regular expression before checking the URL scheme against the blocklist.
✅ **Verification:** Added test cases to `output-safety.test.ts` to ensure that URLs with obfuscated schemes (like `\x01javascript:alert(1)` and `java\x09script:alert(1)`) are correctly identified as unsafe and blocked. Verified by running the vitest test suite.

---
*PR created automatically by Jules for task [9951110404294445985](https://jules.google.com/task/9951110404294445985) started by @Etherll*