### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+## 2024-06-17 - [Fix SSRF vulnerability in Proxy]
+**Vulnerability:** DNS rebinding and TOCTOU attacks were possible in `CredentialProxy` because the URL was validated before the HTTP request was sent, but the hostname could resolve to a different IP during the request.
+**Learning:** Validating hostnames against blocklists before sending requests is insufficient to prevent SSRF due to DNS rebinding. A secure HTTP client must resolve the hostname itself using a secure resolver.
+**Prevention:** Use a custom DNS resolver implementing `reqwest::dns::Resolve` to validate IP addresses synchronously during the connection phase, and disable HTTP redirects.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 

--- a/crates/orbflow-worker/src/credential_proxy.rs
+++ b/crates/orbflow-worker/src/credential_proxy.rs
@@ -14,10 +14,47 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use orbflow_core::OrbflowError;
 use orbflow_core::credential_proxy::{CapabilityRequest, CapabilityResponse};
 use orbflow_core::ports::CredentialStore;
 use orbflow_core::ssrf::{BLOCKED_HOSTNAMES, is_private_ip};
+
+/// A custom DNS resolver that validates resolved IP addresses against SSRF blocklists.
+/// Prevents DNS rebinding and TOCTOU attacks by ensuring the exact IPs the
+/// client connects to are safe.
+#[derive(Clone)]
+struct ProxySsrfSafeResolver;
+
+impl Resolve for ProxySsrfSafeResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let name_str = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs = tokio::net::lookup_host((name_str.as_str(), 0)).await?;
+            let mut safe_addrs = Vec::new();
+            for addr in addrs {
+                if let Some(reason) = is_private_ip(&addr.ip(), false) {
+                    return Err(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        format!(
+                            "credential proxy blocked DNS resolution to {reason} ({})",
+                            addr.ip()
+                        ),
+                    )) as Box<dyn std::error::Error + Send + Sync>);
+                }
+                safe_addrs.push(addr);
+            }
+            if safe_addrs.is_empty() {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "No addresses found",
+                )) as Box<dyn std::error::Error + Send + Sync>);
+            }
+            let addrs_iter: Addrs = Box::new(safe_addrs.into_iter());
+            Ok(addrs_iter)
+        })
+    }
+}
 
 /// Executes capability requests by injecting credentials into HTTP calls.
 ///
@@ -33,9 +70,15 @@ pub struct CredentialProxy {
 impl CredentialProxy {
     /// Creates a new proxy backed by the given credential store.
     pub fn new(cred_store: Arc<dyn CredentialStore>) -> Self {
+        let http_client = reqwest::Client::builder()
+            .dns_resolver(Arc::new(ProxySsrfSafeResolver))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("Failed to build secure HTTP client");
+
         Self {
             cred_store,
-            http_client: reqwest::Client::new(),
+            http_client,
         }
     }
 
@@ -215,4 +258,30 @@ async fn validate_proxy_url(url: &str) -> Result<reqwest::Url, OrbflowError> {
     }
 
     Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn test_credential_proxy_ssrf_resolver_blocks_private() {
+        let resolver = ProxySsrfSafeResolver;
+        // Resolving localhost should be blocked by our resolver
+        let name_str = "localhost";
+        let name = reqwest::dns::Name::from_str(name_str).unwrap_or_else(|_| panic!("Valid Name"));
+
+        let result = resolver.resolve(name).await;
+
+        match result {
+            Err(err) => {
+                assert!(err.to_string().contains("blocked DNS resolution"));
+            }
+            Ok(_) => {
+                panic!("Expected resolver to fail");
+            }
+        }
+    }
 }

--- a/crates/orbflow-worker/src/credential_proxy.rs
+++ b/crates/orbflow-worker/src/credential_proxy.rs
@@ -14,11 +14,11 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use orbflow_core::OrbflowError;
 use orbflow_core::credential_proxy::{CapabilityRequest, CapabilityResponse};
 use orbflow_core::ports::CredentialStore;
 use orbflow_core::ssrf::{BLOCKED_HOSTNAMES, is_private_ip};
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 
 /// A custom DNS resolver that validates resolved IP addresses against SSRF blocklists.
 /// Prevents DNS rebinding and TOCTOU attacks by ensuring the exact IPs the
@@ -40,7 +40,8 @@ impl Resolve for ProxySsrfSafeResolver {
                             "credential proxy blocked DNS resolution to {reason} ({})",
                             addr.ip()
                         ),
-                    )) as Box<dyn std::error::Error + Send + Sync>);
+                    ))
+                        as Box<dyn std::error::Error + Send + Sync>);
                 }
                 safe_addrs.push(addr);
             }
@@ -48,7 +49,8 @@ impl Resolve for ProxySsrfSafeResolver {
                 return Err(Box::new(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     "No addresses found",
-                )) as Box<dyn std::error::Error + Send + Sync>);
+                ))
+                    as Box<dyn std::error::Error + Send + Sync>);
             }
             let addrs_iter: Addrs = Box::new(safe_addrs.into_iter());
             Ok(addrs_iter)


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in Proxy

🚨 Severity: HIGH
💡 Vulnerability: The `CredentialProxy` validated URLs before dispatching HTTP requests, but did not use a secure DNS resolver. This left it vulnerable to DNS rebinding (TOCTOU) attacks, where a benign IP address changes to an internal one during the HTTP request. Furthermore, HTTP redirects were allowed, enabling bypasses via untrusted servers.
🎯 Impact: Attackers could bypass SSRF protections to send requests to internal network services or cloud metadata endpoints.
🔧 Fix: Implemented `ProxySsrfSafeResolver` conforming to `reqwest::dns::Resolve` to validate resolved IPs synchronously during the connection. Configured the proxy `reqwest::Client` to use this resolver, disable redirects, and fail-closed if initialization errors occur.
✅ Verification: Added a unit test, ran the full test suite (make test, vitest), and compiled successfully.

---
*PR created automatically by Jules for task [4484700066728988210](https://jules.google.com/task/4484700066728988210) started by @Etherll*