### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in plugin management

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+
+## 2024-05-24 - Path Traversal bypass via canonicalize fallback
+**Vulnerability:** The HTTP API handler for uninstalling plugins allowed path traversal because it validated directory boundaries using `Path::starts_with()`. When `std::fs::canonicalize()` failed, it gracefully fell back to the uncanonicalized path via `.unwrap_or_else()`. Since `starts_with()` compares components, an uncanonicalized path with `..` segments bypasses the check.
+**Learning:** Rust's `starts_with` does not resolve `..` components. Falling back to an uncanonicalized path upon a `canonicalize` error introduces a subtle bypass for boundary enforcement.
+**Prevention:** Always fail securely when security-critical path transformations like `canonicalize` fail. Never fallback to the raw input.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2773,9 +2773,9 @@ pub async fn uninstall_plugin(
             return Err("symlink");
         }
         // Canonicalize and verify it stays within plugins_dir.
-        let canonical_base = std::fs::canonicalize(&plugins_base)
-            .unwrap_or_else(|_| std::path::PathBuf::from(&plugins_base));
-        let canonical_dir = std::fs::canonicalize(&dir_check).unwrap_or_else(|_| dir_check.clone());
+        let canonical_base =
+            std::fs::canonicalize(&plugins_base).map_err(|_| "canonicalize_base")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check).map_err(|_| "canonicalize_dir")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix path traversal in plugin management

🚨 Severity: CRITICAL
💡 Vulnerability: The HTTP API handler for uninstalling plugins contained a path traversal vulnerability. It attempted to secure directory traversal using `std::fs::canonicalize()` and `Path::starts_with()`, but when `canonicalize()` failed, it gracefully fell back to the uncanonicalized path using `.unwrap_or_else()`. Since `starts_with()` compares path components without resolving `..` segments, an attacker could supply a path containing `..` that would bypass the boundary check.
🎯 Impact: This could allow a malicious actor to delete or manipulate arbitrary files outside of the configured plugins directory.
🔧 Fix: Removed the `.unwrap_or_else()` fallbacks when canonicalizing both the base and target directories. If `canonicalize` fails (e.g., if a requested directory does not exist or due to permission errors), the code now fails securely and returns an error immediately, ensuring that uncanonicalized paths are never passed to the boundary check.
✅ Verification: Tested via unit tests and verified manually that path resolution strictly requires successful canonicalization. All backend test suites pass.

---
*PR created automatically by Jules for task [16135929137916978583](https://jules.google.com/task/16135929137916978583) started by @Etherll*