### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in uninstall_plugin

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+## 2024-05-24 - Path Traversal bypass via canonicalize fallback
+**Vulnerability:** A path traversal check in `uninstall_plugin` relied on `starts_with()` combined with falling back to uncanonicalized paths using `unwrap_or_else` on failure of `std::fs::canonicalize`.
+**Learning:** `starts_with()` compares components, meaning `/plugins/../out` is still seen as starting with `/plugins`. Failing to canonicalize correctly bypasses traversal mitigations.
+**Prevention:** Instead of falling back to unsafe state, failing securely must propagate the canonicalize error so operations are rejected.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2773,10 +2773,9 @@ pub async fn uninstall_plugin(
             return Err("symlink");
         }
         // Canonicalize and verify it stays within plugins_dir.
-        let canonical_base = std::fs::canonicalize(&plugins_base)
-            .map_err(|_| "canonicalize_failed")?;
-        let canonical_dir = std::fs::canonicalize(&dir_check)
-            .map_err(|_| "canonicalize_failed")?;
+        let canonical_base =
+            std::fs::canonicalize(&plugins_base).map_err(|_| "canonicalize_failed")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check).map_err(|_| "canonicalize_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2774,8 +2774,9 @@ pub async fn uninstall_plugin(
         }
         // Canonicalize and verify it stays within plugins_dir.
         let canonical_base = std::fs::canonicalize(&plugins_base)
-            .unwrap_or_else(|_| std::path::PathBuf::from(&plugins_base));
-        let canonical_dir = std::fs::canonicalize(&dir_check).unwrap_or_else(|_| dir_check.clone());
+            .map_err(|_| "canonicalize_failed")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check)
+            .map_err(|_| "canonicalize_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `uninstall_plugin` handler validated directory removal by making sure the target path started with the allowed `plugins_dir` using `starts_with`. However, if `std::fs::canonicalize` failed (e.g. if the file wasn't created yet or we lacked permissions), the code fell back to the uncanonicalized path. Since Rust's `Path::starts_with` compares paths component-wise, an uncanonicalized path like `plugins_base/../etc/passwd` would incorrectly be allowed. 
🎯 Impact: An attacker could bypass the directory boundary check and delete arbitrary directories outside the intended `plugins_dir` causing serious potential data loss.
🔧 Fix: Removed `unwrap_or_else` and instead propagated the canonicalization failure to securely reject the uninstallation request if the path could not be resolved and verified safely.
✅ Verification: Ran `cargo check` and full workspace tests with `make test`. All assertions passed securely.

---
*PR created automatically by Jules for task [2533199377796881477](https://jules.google.com/task/2533199377796881477) started by @Etherll*