### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal bypass in HTTP API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+
+## 2024-05-01 - [Path Traversal Bypass via Canonicalization Fallback]
+**Vulnerability:** A path containment check using `.starts_with()` was bypassed because the preceding `fs::canonicalize` call used `.unwrap_or_else()` to fall back to the raw, uncanonicalized path if the directory didn't exist. This allowed traversal strings like `/base/../target` to satisfy the `starts_with("/base")` check because `starts_with()` compares path components syntactically if they are not canonicalized.
+**Learning:** `starts_with` must only be used on strictly canonicalized paths for containment checks. If canonicalization fails, the operation MUST fail closed.
+**Prevention:** Never use `.unwrap_or_else()` or `.unwrap_or()` to supply an uncanonicalized path as a fallback. Use strict error handling like `.map_err()` to propagate canonicalization failures.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2773,10 +2773,9 @@ pub async fn uninstall_plugin(
             return Err("symlink");
         }
         // Canonicalize and verify it stays within plugins_dir.
-        let canonical_base = std::fs::canonicalize(&plugins_base)
-            .map_err(|_| "canonicalize_failed")?;
-        let canonical_dir = std::fs::canonicalize(&dir_check)
-            .map_err(|_| "canonicalize_failed")?;
+        let canonical_base =
+            std::fs::canonicalize(&plugins_base).map_err(|_| "canonicalize_failed")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check).map_err(|_| "canonicalize_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2774,8 +2774,9 @@ pub async fn uninstall_plugin(
         }
         // Canonicalize and verify it stays within plugins_dir.
         let canonical_base = std::fs::canonicalize(&plugins_base)
-            .unwrap_or_else(|_| std::path::PathBuf::from(&plugins_base));
-        let canonical_dir = std::fs::canonicalize(&dir_check).unwrap_or_else(|_| dir_check.clone());
+            .map_err(|_| "canonicalize_failed")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check)
+            .map_err(|_| "canonicalize_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `uninstall_plugin` HTTP handler used `.unwrap_or_else()` to fall back to an uncanonicalized path if the plugin directory failed to resolve during `fs::canonicalize()`. This allows a path like `/plugins/../secrets` to bypass the subsequent `.starts_with("/plugins")` containment check because `starts_with` syntactically matches path components if neither path is strict.
🎯 Impact: An attacker could potentially delete arbitrary directories on the filesystem that the Orbflow service has write access to.
🔧 Fix: Removed `.unwrap_or_else()` and replaced it with strict error propagation (`.map_err()`). If a path cannot be canonicalized, the verification correctly fails closed, preventing the traversal string from proceeding.
✅ Verification: Ran `cargo check` and `make test` locally to ensure compilability and no backend regressions. The issue is documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13609066579315312781](https://jules.google.com/task/13609066579315312781) started by @Etherll*