### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal bypass in plugin uninstall

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+
+## 2024-07-22 - [Fail Securely on Canonicalization]
+**Vulnerability:** Path Traversal bypass in plugin uninstall via `.unwrap_or_else` fallback.
+**Learning:** When validating file boundaries using `starts_with()`, the validation is completely undermined if canonicalization fails open. Falling back to the raw, uncanonicalized string allows path traversal (`../`) components to persist and bypass the prefix check.
+**Prevention:** File path security checks must fail securely (e.g., using `map_err`) when `canonicalize()` fails. Never fall back to uncanonicalized input for boundary validation.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2773,9 +2773,9 @@ pub async fn uninstall_plugin(
             return Err("symlink");
         }
         // Canonicalize and verify it stays within plugins_dir.
-        let canonical_base = std::fs::canonicalize(&plugins_base)
-            .unwrap_or_else(|_| std::path::PathBuf::from(&plugins_base));
-        let canonical_dir = std::fs::canonicalize(&dir_check).unwrap_or_else(|_| dir_check.clone());
+        let canonical_base =
+            std::fs::canonicalize(&plugins_base).map_err(|_| "canonicalize_failed")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check).map_err(|_| "canonicalize_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Traversal bypass in the `uninstall_plugin` handler. When canonicalizing the plugin directory to verify it resides within the allowed `plugins_dir`, the code used `.unwrap_or_else` to fall back to the uncanonicalized path if canonicalization failed (e.g. if the directory didn't exist yet). Because `starts_with` operates on path components, an uncanonicalized malicious path like `/plugins/../sensitive_dir` would evaluate as starting with `/plugins`, completely bypassing the sandbox check.
🎯 **Impact:** An authenticated attacker with admin privileges could pass a crafted plugin name (if validation was circumvented or weak elsewhere, or via symlinks if the symlink check was bypassed) that escapes the plugins directory, potentially allowing the deletion or modification of arbitrary files on the host system.
🔧 **Fix:** Replaced the `.unwrap_or_else` fallback with `.map_err` to fail securely. If canonicalization of either the base directory or the target directory fails, the endpoint now aborts with a `canonicalize_failed` error, preventing the traversal bypass.
✅ **Verification:** Ran `cargo check` and `cargo test` across the workspace. Confirmed tests pass. Manually verified that canonicalizing an unresolvable path now returns an error instead of returning the uncanonicalized string.

---
*PR created automatically by Jules for task [18230341998777519538](https://jules.google.com/task/18230341998777519538) started by @Etherll*