### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal bypass in plugin deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+## 2024-05-18 - [CRITICAL] Prevent path traversal bypass due to fail-open canonicalization
+**Vulnerability:** Path containment checks used `.unwrap_or_else()` to fall back to an uncanonicalized path if `std::fs::canonicalize()` failed. Because `Path::starts_with()` compares logical path components, a path like `/plugins/../secrets` starts with `/plugins` but traverses outside it.
+**Learning:** Path validation must fail closed. Falling back to uncanonicalized strings or paths defeats the purpose of canonicalization and allows path traversal attacks.
+**Prevention:** Always return an error (fail closed) if `std::fs::canonicalize()` fails during security boundary checks. Never use `.unwrap_or_else()` to bypass it.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2773,10 +2773,10 @@ pub async fn uninstall_plugin(
             return Err("symlink");
         }
         // Canonicalize and verify it stays within plugins_dir.
-        let canonical_base = std::fs::canonicalize(&plugins_base)
-            .map_err(|_| "canonicalize_base_failed")?;
-        let canonical_dir = std::fs::canonicalize(&dir_check)
-            .map_err(|_| "canonicalize_dir_failed")?;
+        let canonical_base =
+            std::fs::canonicalize(&plugins_base).map_err(|_| "canonicalize_base_failed")?;
+        let canonical_dir =
+            std::fs::canonicalize(&dir_check).map_err(|_| "canonicalize_dir_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2774,8 +2774,9 @@ pub async fn uninstall_plugin(
         }
         // Canonicalize and verify it stays within plugins_dir.
         let canonical_base = std::fs::canonicalize(&plugins_base)
-            .unwrap_or_else(|_| std::path::PathBuf::from(&plugins_base));
-        let canonical_dir = std::fs::canonicalize(&dir_check).unwrap_or_else(|_| dir_check.clone());
+            .map_err(|_| "canonicalize_base_failed")?;
+        let canonical_dir = std::fs::canonicalize(&dir_check)
+            .map_err(|_| "canonicalize_dir_failed")?;
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }

--- a/crates/orbflow-httpapi/src/middleware.rs
+++ b/crates/orbflow-httpapi/src/middleware.rs
@@ -279,6 +279,7 @@ struct RateLimitBody {
 }
 
 /// Extracts and validates a workflow ID from the path, then checks rate limit.
+#[allow(clippy::result_large_err)]
 pub async fn check_start_rate_limit(
     limiter: &StartRateLimiter,
     workflow_id: &str,

--- a/crates/orbflow-plugin/tests/sdk_e2e_ts.rs
+++ b/crates/orbflow-plugin/tests/sdk_e2e_ts.rs
@@ -123,7 +123,7 @@ async fn ts_sdk_get_schemas() {
     assert_eq!(schema.plugin_ref, "plugin:weather-forecast");
     assert_eq!(schema.name, "Weather Forecast");
     assert_eq!(schema.category, "utility");
-    assert!(schema.inputs.len() >= 1);
+    assert!(!schema.inputs.is_empty());
     assert!(schema.outputs.len() >= 2);
 }
 

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 

--- a/crates/orbflow-trigger/tests/webhook_signed_query.rs
+++ b/crates/orbflow-trigger/tests/webhook_signed_query.rs
@@ -76,6 +76,7 @@ async fn post_signed(addr: SocketAddr, path: &str, body: &[u8], signature: &str)
     (status, text)
 }
 
+#[allow(clippy::type_complexity)]
 fn recording_callback() -> (
     TriggerCallback,
     mpsc::Receiver<(WorkflowId, TriggerType, HashMap<String, serde_json::Value>)>,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path containment checks in the `uninstall_plugin` handler used `.unwrap_or_else()` to fall back to an uncanonicalized path if `std::fs::canonicalize()` failed. Because `Path::starts_with()` compares logical path components, a path like `/plugins/../secrets` starts with `/plugins` but traverses outside it, allowing deletion of arbitrary directories if the target path didn't exist yet or canonicalization failed.
🎯 Impact: Attackers could potentially trigger arbitrary directory deletion or bypass directory containment restrictions on the host system running the Orbflow HTTP API server.
🔧 Fix: Replaced the fail-open `unwrap_or_else` logic with strict error handling using `map_err`. Path validation must fail closed when canonicalization fails to ensure the security boundary is maintained.
✅ Verification: Ran unit tests using `make test-crate CRATE=orbflow-httpapi` and `make test`. Validated frontend via `pnpm exec vitest run`.

---
*PR created automatically by Jules for task [9235638714669381893](https://jules.google.com/task/9235638714669381893) started by @Etherll*