### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and credential leak in CredentialProxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+## 2026-09-04 - [CRITICAL] Prevent SSRF and Credential Leaks in CredentialProxy
+**Vulnerability:** The CredentialProxy was vulnerable to DNS rebinding SSRF and could leak injected credentials via HTTP 3xx redirects to unauthorized domains.
+**Learning:** Hardened HTTP clients injecting credentials must aggressively prevent redirects (Policy::none()) and use asynchronous DNS resolvers that block private IPs to prevent TOCTOU SSRF attacks.
+**Prevention:** Implement custom DNS resolvers that validate IPs post-resolution and disable redirects on credential-injecting clients.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/middleware.rs
+++ b/crates/orbflow-httpapi/src/middleware.rs
@@ -278,6 +278,7 @@ struct RateLimitBody {
     error: String,
 }
 
+#[allow(clippy::result_large_err)]
 /// Extracts and validates a workflow ID from the path, then checks rate limit.
 pub async fn check_start_rate_limit(
     limiter: &StartRateLimiter,

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 

--- a/crates/orbflow-worker/src/credential_proxy.rs
+++ b/crates/orbflow-worker/src/credential_proxy.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use crate::ssrf::ProxySsrfSafeResolver;
 use orbflow_core::OrbflowError;
 use orbflow_core::credential_proxy::{CapabilityRequest, CapabilityResponse};
 use orbflow_core::ports::CredentialStore;
@@ -35,7 +36,11 @@ impl CredentialProxy {
     pub fn new(cred_store: Arc<dyn CredentialStore>) -> Self {
         Self {
             cred_store,
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder()
+                .dns_resolver(Arc::new(ProxySsrfSafeResolver))
+                .redirect(reqwest::redirect::Policy::none())
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 

--- a/crates/orbflow-worker/src/lib.rs
+++ b/crates/orbflow-worker/src/lib.rs
@@ -4,6 +4,7 @@
 //! Task executor: subscribes to bus, routes to NodeExecutor implementations.
 
 pub mod credential_proxy;
+mod ssrf;
 mod worker;
 
 pub use worker::{Worker, WorkerOptions};

--- a/crates/orbflow-worker/src/ssrf.rs
+++ b/crates/orbflow-worker/src/ssrf.rs
@@ -1,0 +1,39 @@
+use orbflow_core::ssrf::is_private_ip;
+use reqwest::dns::{Addrs, Name, Resolve};
+use tokio::net::lookup_host;
+
+#[derive(Clone)]
+pub(crate) struct ProxySsrfSafeResolver;
+
+impl Resolve for ProxySsrfSafeResolver {
+    fn resolve(&self, name: Name) -> reqwest::dns::Resolving {
+        let name_str = name.as_str().to_string();
+        Box::pin(async move {
+            let addrs = lookup_host((name_str.as_str(), 0))
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+
+            let mut validated = Vec::new();
+            for addr in addrs {
+                if is_private_ip(&addr.ip(), false).is_some() {
+                    return Err(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "credential proxy SSRF policy blocked DNS resolution to private IP",
+                    ))
+                        as Box<dyn std::error::Error + Send + Sync>);
+                }
+                validated.push(addr);
+            }
+
+            if validated.is_empty() {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "credential proxy SSRF policy blocked all resolved IPs",
+                ))
+                    as Box<dyn std::error::Error + Send + Sync>);
+            }
+
+            Ok(Box::new(validated.into_iter()) as Addrs)
+        })
+    }
+}


### PR DESCRIPTION
- 🚨 Severity: CRITICAL
- 💡 Vulnerability: CredentialProxy is vulnerable to SSRF via DNS rebinding and credential leakage via 3xx redirects.
- 🎯 Impact: Attackers can access internal services via SSRF and steal injected API credentials by redirecting requests to attacker-controlled domains.
- 🔧 Fix: Implemented an asynchronous SSRF-safe DNS resolver and disabled redirects on the credential-injecting HTTP client.
- ✅ Verification: Compilation and tests pass.

---
*PR created automatically by Jules for task [13843591927890846777](https://jules.google.com/task/13843591927890846777) started by @Etherll*