### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal Bypass in Plugin Uninstall

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The `isSafeUrl` function checked for unsafe URL schemes (e.g., `javascript:`, `data:`) by trimming and lowercasing the input, but did not handle non-printable control characters. Attackers could bypass the check by injecting characters like `\x01` or tabs (`\x09`) into the URL scheme (e.g., `java\x09script:alert(1)`), which the browser would ignore and execute as XSS.
 **Learning:** Browsers are highly lenient when parsing URL schemes and will strip out invalid control characters before evaluation. Simple string prefix checks (`startsWith`) are insufficient for validating URLs because they don't account for these obfuscation techniques.
 **Prevention:** Before validating a URL scheme against a blocklist, always sanitize the input by explicitly stripping non-printable control characters (`[\x00-\x1F\x7F-\x9F]`) using a regex.
+## 2026-05-18 - [HIGH] Prevent Path Traversal Bypass via Canonicalization Fail-Open
+**Vulnerability:** The `uninstall_plugin` handler used `std::fs::canonicalize` for path traversal prevention but used `.unwrap_or_else` to fallback to an uncanonicalized string if it failed.
+**Learning:** When canonicalizing paths for containment validation (e.g., preventing path traversal), securely canonicalize its parent directory using `path.parent()` rather than failing open or falling back to an uncanonicalized string.
+**Prevention:** Ensure path traversal validation using `starts_with` strictly compares fully canonicalized paths, securely failing closed on errors.

--- a/crates/orbflow-config/tests/docker_config_security.rs
+++ b/crates/orbflow-config/tests/docker_config_security.rs
@@ -64,9 +64,8 @@ fn shipped_docker_config_keeps_grpc_disabled() {
 #[test]
 fn shipped_docker_config_grpc_port_is_default() {
     let path = docker_yaml_path();
-    let cfg = Config::load(&path).unwrap_or_else(|e| {
-        panic!("Config::load({}) failed: {e}", path.display())
-    });
+    let cfg = Config::load(&path)
+        .unwrap_or_else(|e| panic!("Config::load({}) failed: {e}", path.display()));
 
     assert_eq!(
         cfg.grpc.port, 9090,

--- a/crates/orbflow-engine/tests/saga_integration.rs
+++ b/crates/orbflow-engine/tests/saga_integration.rs
@@ -499,11 +499,7 @@ impl Bus for CompensationFailingBus {
         self.inner.publish(subject, data).await
     }
 
-    async fn subscribe(
-        &self,
-        subject: &str,
-        handler: MsgHandler,
-    ) -> Result<(), OrbflowError> {
+    async fn subscribe(&self, subject: &str, handler: MsgHandler) -> Result<(), OrbflowError> {
         self.inner.subscribe(subject, handler).await
     }
 
@@ -664,10 +660,7 @@ async fn saga_dispatch_failure_leaves_node_pending_for_recovery() {
     // compensation execution.
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let inst = store
-        .get_instance(&inst_id)
-        .await
-        .expect("get_instance");
+    let inst = store.get_instance(&inst_id).await.expect("get_instance");
     let saga = inst.saga.as_ref().expect("saga state present");
     assert!(
         saga.compensating,

--- a/crates/orbflow-httpapi/src/handlers.rs
+++ b/crates/orbflow-httpapi/src/handlers.rs
@@ -2773,9 +2773,14 @@ pub async fn uninstall_plugin(
             return Err("symlink");
         }
         // Canonicalize and verify it stays within plugins_dir.
-        let canonical_base = std::fs::canonicalize(&plugins_base)
-            .unwrap_or_else(|_| std::path::PathBuf::from(&plugins_base));
-        let canonical_dir = std::fs::canonicalize(&dir_check).unwrap_or_else(|_| dir_check.clone());
+        let canonical_base = match std::fs::canonicalize(&plugins_base) {
+            Ok(p) => p,
+            Err(_) => return Err("canonicalize_failed"),
+        };
+        let canonical_dir = match std::fs::canonicalize(&dir_check) {
+            Ok(p) => p,
+            Err(_) => return Err("canonicalize_failed"),
+        };
         if !canonical_dir.starts_with(&canonical_base) {
             return Err("outside_base");
         }
@@ -2786,6 +2791,9 @@ pub async fn uninstall_plugin(
     match check_result {
         Ok(Ok(())) => {}
         Ok(Err("not_found")) => return write_error(StatusCode::NOT_FOUND, "plugin not installed"),
+        Ok(Err("canonicalize_failed")) => {
+            return write_error(StatusCode::BAD_REQUEST, "invalid plugin directory");
+        }
         Ok(Err(_)) => return write_error(StatusCode::BAD_REQUEST, "invalid plugin directory"),
         Err(_) => return write_error(StatusCode::INTERNAL_SERVER_ERROR, "check task failed"),
     }

--- a/crates/orbflow-httpapi/src/middleware.rs
+++ b/crates/orbflow-httpapi/src/middleware.rs
@@ -279,6 +279,7 @@ struct RateLimitBody {
 }
 
 /// Extracts and validates a workflow ID from the path, then checks rate limit.
+#[allow(clippy::result_large_err)]
 pub async fn check_start_rate_limit(
     limiter: &StartRateLimiter,
     workflow_id: &str,

--- a/crates/orbflow-postgres/tests/zeroizing_deref.rs
+++ b/crates/orbflow-postgres/tests/zeroizing_deref.rs
@@ -12,8 +12,8 @@
 //! `Zeroizing<Vec<u8>>` implements `Deref<Target = Vec<u8>>` and `Vec<u8>`
 //! coerces to `&[u8]` in a reference context.
 
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use zeroize::Zeroizing;
 
 /// T-08 Risk #1: Zeroizing<Vec<u8>> derefs into serde_json::from_slice without
@@ -74,8 +74,7 @@ fn zeroized_buffer_value_is_still_readable_after_parse() {
 
     // After from_slice the parsed Value lives in heap memory NOT covered by Zeroizing.
     // This is the documented residual from T-08 (see PLAN.md Risk #12).
-    let parsed: HashMap<String, Value> =
-        serde_json::from_slice(&plaintext).expect("parse");
+    let parsed: HashMap<String, Value> = serde_json::from_slice(&plaintext).expect("parse");
     let password = parsed["password"].as_str().expect("string");
     assert_eq!(password, "hunter2");
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `uninstall_plugin` API handler in `orbflow-httpapi` used a 'fail-open' pattern when canonicalizing paths for directory containment checks. If `std::fs::canonicalize` failed, it used `.unwrap_or_else(|_| dir_check.clone())` to fall back to the uncanonicalized path. This allows an attacker to construct a path with `../` that forces a canonicalization failure but matches the prefix check because string comparison evaluates against uncanonicalized components.
🎯 **Impact**: Path Traversal. An attacker with admin privileges could craft a malicious plugin name containing `../` to delete arbitrary directories outside the `plugins_dir` via the `uninstall_plugin` endpoint.
🔧 **Fix**: Modified the canonicalization logic to securely fail closed. If `std::fs::canonicalize` fails, the handler now correctly returns a `400 BAD_REQUEST` instead of falling back to an unsafe, uncanonicalized string representation.
✅ **Verification**: Compiled with `cargo check`, ran all backend unit tests via `make test-crate CRATE=orbflow-httpapi` and all workspace frontend tests, all passing successfully. Added journal entry recording the canonicalization fail-open pattern.

---
*PR created automatically by Jules for task [14193457742690557554](https://jules.google.com/task/14193457742690557554) started by @Etherll*